### PR TITLE
Update Python3 handler to return result

### DIFF
--- a/template/python3-debian/function/handler.py
+++ b/template/python3-debian/function/handler.py
@@ -1,2 +1,7 @@
-def handle(st):
-    print(st)
+def handle(req):
+    """handle a request to the function
+    Args:
+        req (str): request body
+    """
+
+    return req

--- a/template/python3-debian/index.py
+++ b/template/python3-debian/index.py
@@ -15,4 +15,6 @@ def get_stdin():
 
 if(__name__ == "__main__"):
     st = get_stdin()
-    handler.handle(st)
+    ret = handler.handle(st)
+    if ret != None:
+        print(ret)


### PR DESCRIPTION
The handler should return instead of printing result to match the
Python3 example in the openfaas/templates repo.

Signed-off-by: Ron Rivera <roncrivera@gmail.com>